### PR TITLE
Refactor/composition api

### DIFF
--- a/client/components/ChatroomRow/Image.vue
+++ b/client/components/ChatroomRow/Image.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ChatroomImage',
   props: {
     message: {

--- a/client/components/ChatroomRow/Message.vue
+++ b/client/components/ChatroomRow/Message.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ChatroomMessage',
   props: {
     message: {

--- a/client/components/ChatroomRow/Sticker.vue
+++ b/client/components/ChatroomRow/Sticker.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ChatroomSticker'
 })
 </script>

--- a/client/components/ChatroomRow/index.vue
+++ b/client/components/ChatroomRow/index.vue
@@ -12,13 +12,13 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue'
+import { computed, defineComponent } from '@nuxtjs/composition-api'
 import { Message } from '~/mocks/types'
 const ChatroomMessage = () => import('~/components/ChatroomRow/Message.vue')
 const ChatroomImage = () => import('~/components/ChatroomRow/Image.vue')
 const ChatroomSticker = () => import('~/components/ChatroomRow/Sticker.vue')
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ChatroomRow',
   components: {
     ChatroomMessage,
@@ -27,21 +27,24 @@ export default Vue.extend({
   },
   props: {
     message: {
-      type: Object,
+      type: Object as () => Message,
       required: true
-    } as PropOptions<Message>,
+    },
     myName: {
       type: String,
       required: true
     }
   },
-  computed: {
-    renderComponent (): string {
+  setup (props) {
+    const renderComponent = computed(() => {
       const prefix = 'chatroom'
-      return prefix + '-' + this.message.type
-    },
-    fromMe (): boolean {
-      return this.myName === this.message.name
+      return prefix + '-' + props.message.type
+    })
+    const fromMe = computed((): boolean => props.myName === props.message.name)
+
+    return {
+      renderComponent,
+      fromMe
     }
   }
 })

--- a/client/components/ChatroomSearchBar.vue
+++ b/client/components/ChatroomSearchBar.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, ref } from '@nuxtjs/composition-api'
 import {
   mdiChevronRight,
   mdiMagnify,
@@ -63,7 +63,7 @@ import {
   mdiCloseCircleOutline
 } from '@mdi/js'
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ChatroomToolBar',
   props: {
     visible: {
@@ -71,14 +71,15 @@ export default Vue.extend({
       required: true
     }
   },
-  data () {
+  setup () {
+    const search = ref('')
     return {
       mdiChevronRight,
       mdiMagnify,
       mdiAccountOutline,
       mdiCalendarTextOutline,
       mdiCloseCircleOutline,
-      search: ''
+      search
     }
   }
 })

--- a/client/components/ChatroomSetting.vue
+++ b/client/components/ChatroomSetting.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import {
   mdiDotsHorizontal,
   mdiFileEditOutline,
@@ -44,48 +44,50 @@ import {
   mdiBroom,
   mdiTrashCanOutline
 } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'ChatroomSetting',
-  data () {
+  setup () {
+    const settings = [
+      {
+        icon: mdiFileEditOutline,
+        label: 'edit',
+        cb: () => {}
+      },
+      {
+        icon: mdiInformationOutline,
+        label: 'info',
+        cb: () => {}
+      },
+      {
+        icon: mdiBellOffOutline,
+        label: 'mute',
+        cb: () => {}
+      },
+      {
+        icon: mdiArchiveArrowDownOutline,
+        label: 'archive',
+        cb: () => {}
+      },
+      {
+        icon: mdiUpdate,
+        label: 'scheduled massages',
+        cb: () => {}
+      },
+      {
+        icon: mdiBroom,
+        label: 'clear chat history',
+        cb: () => {}
+      },
+      {
+        icon: mdiTrashCanOutline,
+        label: 'delete and leave',
+        cb: () => {}
+      }
+    ]
+
     return {
       mdiDotsHorizontal,
-      settings: [
-        {
-          icon: mdiFileEditOutline,
-          label: 'edit',
-          cb: () => {}
-        },
-        {
-          icon: mdiInformationOutline,
-          label: 'info',
-          cb: () => {}
-        },
-        {
-          icon: mdiBellOffOutline,
-          label: 'mute',
-          cb: () => {}
-        },
-        {
-          icon: mdiArchiveArrowDownOutline,
-          label: 'archive',
-          cb: () => {}
-        },
-        {
-          icon: mdiUpdate,
-          label: 'scheduled massages',
-          cb: () => {}
-        },
-        {
-          icon: mdiBroom,
-          label: 'clear chat history',
-          cb: () => {}
-        },
-        {
-          icon: mdiTrashCanOutline,
-          label: 'delete and leave',
-          cb: () => {}
-        }
-      ]
+      settings
     }
   }
 })

--- a/client/components/ChatroomStickerMenu.vue
+++ b/client/components/ChatroomStickerMenu.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import {
   mdiStickerEmoji,
   mdiMagnify,
@@ -86,9 +86,24 @@ import {
   mdiStickerOutline,
   mdiGif
 } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'ChatroomStickerMenu',
-  data () {
+  setup () {
+    const tabs = [
+      {
+        label: 'emoji',
+        icon: mdiEmoticonHappyOutline
+      },
+      {
+        label: 'sticker',
+        icon: mdiStickerOutline
+      },
+      {
+        label: 'gif',
+        icon: mdiGif
+      }
+    ]
+
     return {
       mdiStickerEmoji,
       mdiMagnify,
@@ -96,20 +111,7 @@ export default Vue.extend({
       mdiStickerOutline,
       mdiGif,
       search: '',
-      tabs: [
-        {
-          label: 'emoji',
-          icon: mdiEmoticonHappyOutline
-        },
-        {
-          label: 'sticker',
-          icon: mdiStickerOutline
-        },
-        {
-          label: 'gif',
-          icon: mdiGif
-        }
-      ]
+      tabs
     }
   }
 })

--- a/client/components/ChatroomTimeBar.vue
+++ b/client/components/ChatroomTimeBar.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ChatroomTimeBar',
   props: {
     message: {

--- a/client/components/ChatroomUpload.vue
+++ b/client/components/ChatroomUpload.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import {
   mdiPaperclip,
   mdiImageOutline,
@@ -42,38 +42,39 @@ import {
   mdiFileOutline,
   mdiMapMarkerOutline,
 } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'ChatroomUpload',
-  data () {
+  setup () {
+    const uploads = [
+      {
+        icon: mdiImageOutline,
+        label: 'photo or video',
+        cb: () => {}
+      },
+      {
+        icon: mdiCameraOutline,
+        label: 'camera',
+        cb: () => {}
+      },
+      {
+        icon: mdiPollBoxOutline,
+        label: 'poll',
+        cb: () => {}
+      },
+      {
+        icon: mdiFileOutline,
+        label: 'file',
+        cb: () => {}
+      },
+      {
+        icon: mdiMapMarkerOutline,
+        label: 'location',
+        cb: () => {}
+      }
+    ]
     return {
       mdiPaperclip,
-      uploads: [
-        {
-          icon: mdiImageOutline,
-          label: 'photo or video',
-          cb: () => {}
-        },
-        {
-          icon: mdiCameraOutline,
-          label: 'camera',
-          cb: () => {}
-        },
-        {
-          icon: mdiPollBoxOutline,
-          label: 'poll',
-          cb: () => {}
-        },
-        {
-          icon: mdiFileOutline,
-          label: 'file',
-          cb: () => {}
-        },
-        {
-          icon: mdiMapMarkerOutline,
-          label: 'location',
-          cb: () => {}
-        }
-      ]
+      uploads
     }
   }
 })

--- a/client/components/Header.vue
+++ b/client/components/Header.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'Header'
 })
 </script>

--- a/client/components/README.md
+++ b/client/components/README.md
@@ -1,7 +1,0 @@
-# COMPONENTS
-
-**This directory is not required, you can delete it if you don't want to use it.**
-
-The components directory contains your Vue.js Components.
-
-_Nuxt.js doesn't supercharge these components._

--- a/client/components/SettingsRadio.vue
+++ b/client/components/SettingsRadio.vue
@@ -16,9 +16,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { computed, defineComponent } from '@nuxtjs/composition-api'
 import { mdiCheckCircle } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'SettingsRadio',
   props: {
     id: {
@@ -34,19 +34,15 @@ export default Vue.extend({
       type: [Number, String, Boolean]
     }
   },
-  data () {
+  setup (props, { emit }) {
+    const selected = computed({
+      get: (): number | string | boolean => props.value,
+      set: (newValue: number | string | boolean) => { emit('input', newValue) }
+    })
+
     return {
-      mdiCheckCircle
-    }
-  },
-  computed: {
-    selected: {
-      get (): number | string | boolean {
-        return this.value
-      },
-      set (val: number | string | boolean) {
-        this.$emit('input', val)
-      }
+      mdiCheckCircle,
+      selected
     }
   }
 })

--- a/client/components/dialog/AddContactDialog.vue
+++ b/client/components/dialog/AddContactDialog.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+import { computed, defineComponent } from '@nuxtjs/composition-api'
 export default {
   name: 'AddContactDialog',
   props: {
@@ -13,14 +14,13 @@ export default {
       type: Boolean
     }
   },
-  computed: {
-    show: {
-      get () {
-        return this.value
-      },
-      set (value) {
-        this.$emit('input', value)
-      }
+  setup (props, { emit }) {
+    const show = computed({
+      get: () => props.value,
+      set: value => { emit('input', value) }
+    })
+    return {
+      show
     }
   }
 }

--- a/client/components/dialog/CountrySelectorDialog.vue
+++ b/client/components/dialog/CountrySelectorDialog.vue
@@ -38,62 +38,61 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { computed, defineComponent, Ref, ref, useFetch, watch } from '@nuxtjs/composition-api'
 import { getCountryOptions } from '~/mocks'
 import { Option } from '~/mocks/types'
-interface CountrySelectorDialog {
-  search: string
-  selected: string
-  options: Array<Option>
-}
-export default Vue.extend({
+
+export default  defineComponent({
   name: 'CountrySelectorDialog',
+  fetchOnServer: false,
   props: {
-    value: Boolean,
-    country: String,
-    code: String
-  },
-  data () {
-    return {
-      search: '',
-      selected: '',
-      options: []
-    } as CountrySelectorDialog
-  },
-  watch: {
-    code (text: string) {
-      let country = ''
-      if (text.length) {
-        let target: Option | undefined = this.options.find(option => option.value.includes(text))
-        country = target?.name || ''
-      }
-      this.$emit('update:country', country)
-    }
-  },
-  computed: {
-    show: {
-      get (): Boolean {
-        return this.value
-      },
-      set (value: Boolean): void {
-        this.$emit('input', value)
-      }
+    value: {
+      type: Boolean,
+      required: true
     },
-    searchOptions (): Array<Option> {
-      return this.options
+    country: {
+      type: String,
+      required: true
+    },
+    code: {
+      type: String,
+      requird: true
     }
   },
-  methods: {
-    select (item: Option) {
-      this.$emit('update:country', item.name)
-      this.$emit('update:code', item.value)
-      this.show = false
+  setup (props, { emit }) {
+    const search = ref('')
+    const selected = ref('')
+    let options: Ref<Array<Option>> = ref([])
+
+    const show = computed({
+      get: (): Boolean => props.value,
+      set: (value: Boolean): void => { emit('input', value) }
+    })
+    // TODO: filter search options
+    const searchOptions = computed((): Array<Option> => options.value)
+
+    // TODO: guess user location
+    const setDefaultCountryAndCode = () => {}
+
+    const select = (item: Option) => {
+      emit('update:country', item.name)
+      emit('update:code', item.value)
+      show.value = false
     }
-  },
-  async fetch () {
-    this.options = await getCountryOptions()
-  },
-  fetchOnServer: false
+
+    useFetch(async () => {
+      options.value = await getCountryOptions()
+      setDefaultCountryAndCode()
+    })
+
+    return {
+      search,
+      selected,
+      searchOptions,
+      show,
+      select
+    }
+  }
 })
 </script>
 

--- a/client/components/navigator/ChatroomsList.vue
+++ b/client/components/navigator/ChatroomsList.vue
@@ -31,13 +31,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive, computed, useAsync } from '@nuxtjs/composition-api'
 import { getChatrooms } from '~/mocks'
-import { Chatroom } from '~/mocks/types'
-interface ChatroomNavigator {
-  chatrooms: Array<Chatroom>
-}
-export default Vue.extend({
+export default defineComponent({
   name: 'MessagesList',
   props: {
     chatroomId: {
@@ -45,23 +41,18 @@ export default Vue.extend({
       required: true
     }
   },
-  data () {
+  setup (props, { emit }) {
+    const chatrooms = useAsync(() => getChatrooms())
+
+    const activeChatroomId = computed({
+      get: (): number | string => props.chatroomId,
+      set: (chatroomId: number | string) => { emit('update:chatroomId', chatroomId) }
+    })
+
     return {
-      chatrooms: []
-    } as ChatroomNavigator
-  },
-  computed: {
-    activeChatroomId: {
-      get (): number | string {
-        return this.chatroomId
-      },
-      set (chatroomId: number) {
-        this.$emit('update:chatroomId', chatroomId)
-      }
+      chatrooms,
+      activeChatroomId
     }
-  },
-  async fetch () {
-    this.chatrooms = await getChatrooms()
   }
 })
 </script>

--- a/client/components/navigator/ContactsList.vue
+++ b/client/components/navigator/ContactsList.vue
@@ -46,17 +46,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive, computed, useAsync } from '@nuxtjs/composition-api'
 import { getContacts } from '~/mocks'
 import { mdiAccountPlusOutline } from '@mdi/js'
 import AddContactDialog from '~/components/dialog/AddContactDialog.vue'
 import { Contact } from '~/mocks/types'
-interface ContactsNavigator {
-  contacts: Array<Contact>,
-  mdiAccountPlusOutline: string,
-  visible: Record<string, boolean>
-}
-export default Vue.extend({
+export default defineComponent({
   name: 'ContactsNavigator',
   components: {
     AddContactDialog
@@ -67,27 +62,21 @@ export default Vue.extend({
       required: true
     }
   },
-  data () {
+  setup (props, { emit }) {
+    const contacts = useAsync(() => getContacts())
+    const visible = reactive({ addContact: false })
+
+    const activeChatroomId = computed({
+      get: (): number | string => props.chatroomId,
+      set: (chatroomId: number | string) => { emit('update:chatroomId', chatroomId) }
+    })
+
     return {
-      contacts: [],
+      contacts,
+      visible,
       mdiAccountPlusOutline,
-      visible: {
-        addContact: false
-      }
-    } as ContactsNavigator
-  },
-  computed: {
-    activeChatroomId: {
-      get (): number | string {
-        return this.chatroomId
-      },
-      set (chatroomId: number) {
-        this.$emit('update:chatroomId', chatroomId)
-      }
+      activeChatroomId
     }
-  },
-  async fetch () {
-    this.contacts = await getContacts()
   }
 })
 </script>

--- a/client/components/navigator/ContactsList.vue
+++ b/client/components/navigator/ContactsList.vue
@@ -13,7 +13,7 @@
       <v-list-item-group color="primary darken-1" v-model="activeChatroomId">
         <template v-for="contact in contacts">
           <v-list-item
-            :key="`contact-${ contact.chatroom.id }`"
+            :key="`contact-${ contact.id }`"
             :value="contact.chatroom.id"
             class="caption pr-0"
           >

--- a/client/components/navigator/ContactsTool.vue
+++ b/client/components/navigator/ContactsTool.vue
@@ -21,16 +21,17 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, ref } from '@nuxtjs/composition-api'
 import {
   mdiMagnify,
   mdiPencil
 } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'ContactsTool',
-  data () {
+  setup () {
+    const search = ref('')
     return {
-      search: '',
+      search,
       mdiMagnify,
       mdiPencil
     }

--- a/client/components/navigator/RecentCallsList.vue
+++ b/client/components/navigator/RecentCallsList.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'RecentCallsList'
 })
 </script>

--- a/client/components/navigator/RecentCallsTool.vue
+++ b/client/components/navigator/RecentCallsTool.vue
@@ -23,11 +23,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import { mdiCogOutline } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'RecentCallsTool',
-  data () {
+  setup () {
     return {
       mdiCogOutline
     }

--- a/client/components/navigator/SettingsList.vue
+++ b/client/components/navigator/SettingsList.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive } from '@nuxtjs/composition-api'
 import {
   mdiAccountPlusOutline,
   mdiChevronRight,
@@ -91,98 +91,102 @@ import {
   mdiHelpCircle,
   mdiDotsHorizontalCircle
 } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'SettingsList',
-  data () {
+  setup () {
+    const user = reactive({
+      avatar: 'https://cdn2.ettoday.net/images/404/d404061.jpg',
+      name: 'Jason Chang',
+      phone: '+886 XXX XXX XXX',
+      tag: '@Lilybon'
+    })
+    const links = [
+      {
+        icon: mdiCog,
+        iconColor: 'primary darken-2',
+        name: 'General',
+        route: 'settings-general-settings',
+        background: 'info'
+      },
+      {
+        icon: null,
+        iconColor: 'info',
+        name: 'Notification and Sounds',
+        route: 'settings-notifications',
+        background: 'error'
+      },
+      {
+        icon: mdiLock,
+        iconColor: 'info',
+        name: 'Privacy and Security',
+        route: 'settings-privacy-and-security',
+        background: 'primary darken-1'
+      },
+      {
+        icon: mdiDatabase,
+        iconColor: 'info',
+        name: 'Data and Storage',
+        route: 'settings-data-and-storage',
+        background: 'success'
+      },
+      {
+        icon: mdiLaptop,
+        iconColor: 'info',
+        name: 'Active Sessions',
+        route: 'settings-active-sessions',
+        background: 'warning'
+      },
+      {
+        icon: mdiFountainPen,
+        iconColor: 'info',
+        name: 'Appearance',
+        route: 'settings-appearance',
+        background: 'primary lighten-1'
+      },
+      {
+        icon: mdiWeb,
+        iconColor: 'info',
+        name: 'Language',
+        route: 'settings-language',
+        background: 'secondary'
+      },
+      {
+        icon: mdiStickerOutline,
+        iconColor: 'info',
+        name: 'Stickers',
+        route: 'settings-stickers',
+        background: 'warning'
+      },
+      {
+        icon: mdiFolder,
+        iconColor: 'info',
+        name: 'Chat Folders',
+        route: 'settings-chat-folders',
+        background: 'secondary'
+      }
+    ]
+    const helps = [
+      {
+        icon: mdiHelpCircle,
+        iconColor: 'info',
+        name: 'GoChat FAQ',
+        background: 'primary lighten-1'
+      },
+      {
+        icon: mdiDotsHorizontalCircle,
+        iconColor: 'info',
+        name: 'Ask a Question',
+        background: 'info darken-2'
+      }
+    ]
+
     return {
       mdiAccountPlusOutline,
       mdiChevronRight,
-      user: {
-        avatar: 'https://cdn2.ettoday.net/images/404/d404061.jpg',
-        name: 'Jason Chang',
-        phone: '+886 XXX XXX XXX',
-        tag: '@Lilybon'
-      },
-      links: [
-        {
-          icon: mdiCog,
-          iconColor: 'primary darken-2',
-          name: 'General',
-          route: 'settings-general-settings',
-          background: 'info'
-        },
-        {
-          icon: null,
-          iconColor: 'info',
-          name: 'Notification and Sounds',
-          route: 'settings-notifications',
-          background: 'error'
-        },
-        {
-          icon: mdiLock,
-          iconColor: 'info',
-          name: 'Privacy and Security',
-          route: 'settings-privacy-and-security',
-          background: 'primary darken-1'
-        },
-        {
-          icon: mdiDatabase,
-          iconColor: 'info',
-          name: 'Data and Storage',
-          route: 'settings-data-and-storage',
-          background: 'success'
-        },
-        {
-          icon: mdiLaptop,
-          iconColor: 'info',
-          name: 'Active Sessions',
-          route: 'settings-active-sessions',
-          background: 'warning'
-        },
-        {
-          icon: mdiFountainPen,
-          iconColor: 'info',
-          name: 'Appearance',
-          route: 'settings-appearance',
-          background: 'primary lighten-1'
-        },
-        {
-          icon: mdiWeb,
-          iconColor: 'info',
-          name: 'Language',
-          route: 'settings-language',
-          background: 'secondary'
-        },
-        {
-          icon: mdiStickerOutline,
-          iconColor: 'info',
-          name: 'Stickers',
-          route: 'settings-stickers',
-          background: 'warning'
-        },
-        {
-          icon: mdiFolder,
-          iconColor: 'info',
-          name: 'Chat Folders',
-          route: 'settings-chat-folders',
-          background: 'secondary'
-        },
-      ],
-      helps: [
-        {
-          icon: mdiHelpCircle,
-          iconColor: 'info',
-          name: 'GoChat FAQ',
-          background: 'primary lighten-1'
-        },
-        {
-          icon: mdiDotsHorizontalCircle,
-          iconColor: 'info',
-          name: 'Ask a Question',
-          background: 'info darken-2'
-        }
-      ]
+      user,
+      links,
+      helps
     }
-  }
+  },
 })
 </script>

--- a/client/components/navigator/SettingsTool.vue
+++ b/client/components/navigator/SettingsTool.vue
@@ -27,14 +27,16 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, ref } from '@nuxtjs/composition-api'
 import { mdiMagnify } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'SettingsTool',
-  data () {
+  setup () {
+    const search = ref('')
+
     return {
       mdiMagnify,
-      search: ''
+      search
     }
   }
 })

--- a/client/components/wrapper/SettingsDialog.vue
+++ b/client/components/wrapper/SettingsDialog.vue
@@ -3,9 +3,10 @@
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
 
-}
+})
 </script>
 
 <style>

--- a/client/components/wrapper/SettingsGroup.vue
+++ b/client/components/wrapper/SettingsGroup.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'SettingsGroupWrapper',
   props: {
     title: {

--- a/client/components/wrapper/SettingsRow.vue
+++ b/client/components/wrapper/SettingsRow.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent, computed } from '@nuxtjs/composition-api'
+export default  defineComponent({
   name: 'SettingsRowWrapper',
   props: {
     title: {
@@ -33,11 +33,14 @@ export default Vue.extend({
       default: ''
     }
   },
-  computed: {
-    labelFor (): string {
-      let label = this.labelPrefix + '__' + this.title.replace(/\s/g, '-')
-      if (this.labelSuffix.length) label += '__' + this.labelSuffix
+  setup (props) {
+    const labelFor = computed((): string => {
+      let label = props.labelPrefix + '__' + props.title.replace(/\s/g, '-')
+      if (props.labelSuffix.length) label += '__' + props.labelSuffix
       return label
+    })
+    return {
+      labelFor
     }
   }
 })

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   moduleNameMapper: {
+    '@nuxtjs/composition-api': '@nuxtjs/composition-api/lib/entrypoint.js',
     '^@/(.*)$': '<rootDir>/$1',
     '^~/(.*)$': '<rootDir>/$1',
     '^vue$': 'vue/dist/vue.common.js'

--- a/client/layouts/README.md
+++ b/client/layouts/README.md
@@ -1,7 +1,0 @@
-# LAYOUTS
-
-**This directory is not required, you can delete it if you don't want to use it.**
-
-This directory contains your Application Layouts.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/views#layouts).

--- a/client/layouts/error.vue
+++ b/client/layouts/error.vue
@@ -13,20 +13,21 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   props: {
     error: {
       type: Object,
       default: null
     }
   },
-  data () {
+  setup () {
     return {
       pageNotFound: '404 Not Found',
       otherError: 'An error occurred'
     }
   },
+  // TODO: replace head to composition api syntax
   head () {
     const title: string =
       this.error.statusCode === 404 ? this.pageNotFound : this.otherError

--- a/client/layouts/simple.vue
+++ b/client/layouts/simple.vue
@@ -10,8 +10,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'Simple'
 })
 </script>

--- a/client/mocks/data.ts
+++ b/client/mocks/data.ts
@@ -57,3 +57,11 @@ export const messages = [
     --compressed
   `
 ]
+
+export const stickerNames = [
+  '杰哥不要啦',
+  'igotallday_fans',
+  'Peepo pepe',
+  'Bobby Hill',
+  'PEPEtopAnim'
+]

--- a/client/mocks/index.ts
+++ b/client/mocks/index.ts
@@ -1,6 +1,6 @@
-import { names, images, messages } from './data'
+import { names, images, messages, stickerNames } from './data'
 import { getRandomNumber, pickFromArray } from './random'
-import { Contact, Chatroom, Option } from './types'
+import { Contact, Chatroom, Option, Sticker } from './types'
 
 export const getCountryOptions = (): Promise<Array<Option>> =>
   Promise.resolve(
@@ -13,10 +13,10 @@ export const getCountryOptions = (): Promise<Array<Option>> =>
 export const getContacts = (): Promise<Array<Contact>> =>
   Promise.resolve(
     names
-      .map(name => ({
-        id: getRandomNumber(100),
+      .map((name, index) => ({
+        id: index,
         chatroom: {
-          id: 100 + getRandomNumber(100)
+          id: index
         },
         name,
         avatar: pickFromArray(images),
@@ -67,4 +67,13 @@ export const getChatrooms = (): Promise<Array<Chatroom>> =>
           time: '10:30 PM'
         }
       }))
+  )
+
+export const getStickers = (): Promise<Array<Sticker>> =>
+  Promise.resolve(
+    Array.from(Array(5), (_, index) => ({
+      id: index,
+      name: pickFromArray(stickerNames),
+      count: getRandomNumber(100)
+    }))
   )

--- a/client/mocks/index.ts
+++ b/client/mocks/index.ts
@@ -2,25 +2,27 @@ import { names, images, messages } from './data'
 import { getRandomNumber, pickFromArray } from './random'
 import { Contact, Chatroom, Option } from './types'
 
-export const getCountryOptions = (): Array<Option> => 
-  new Array(50)
-    .fill(0)
-    .map((_, i) => ({
-      name: `country-${i}`,
-      value: `+ ${i}`
+export const getCountryOptions = (): Promise<Array<Option>> =>
+  Promise.resolve(
+    Array.from(Array(50), (_, index) => ({
+      name: `country-${ index }`,
+      value: `+ ${ index }`
     }))
+  )
 
-export const getContacts = (): Array<Contact> =>
-  names
-    .map(name => ({
-      id: getRandomNumber(100),
-      chatroom: {
-        id: 100 + getRandomNumber(100)
-      },
-      name,
-      avatar: pickFromArray(images),
-      last_seen: 'last seen 7 minutes ago'
-    }))
+export const getContacts = (): Promise<Array<Contact>> =>
+  Promise.resolve(
+    names
+      .map(name => ({
+        id: getRandomNumber(100),
+        chatroom: {
+          id: 100 + getRandomNumber(100)
+        },
+        name,
+        avatar: pickFromArray(images),
+        last_seen: 'last seen 7 minutes ago'
+      }))
+  )
 
 export const getChatroomMessages = (messageLength = 40) => {
   const generators = [
@@ -47,20 +49,22 @@ export const getChatroomMessages = (messageLength = 40) => {
       time: new Date()
     })
   ]
-  return Array.from(Array(messageLength), () => pickFromArray(generators)())
+  return Promise.resolve(Array.from(Array(messageLength), () => pickFromArray(generators)()))
 }
 
-export const getChatrooms = (): Array<Chatroom> =>
-  names
-    .map((name, i) => ({
-      id: i,
-      name,
-      avatar: pickFromArray(images),
-      unread: getRandomNumber(100),
-      last_message: {
-        type: '',
-        sender: 'Lilybon',
-        content: '123',
-        time: '10:30 PM'
-      }
-    }))
+export const getChatrooms = (): Promise<Array<Chatroom>> =>
+  Promise.resolve(
+    names
+      .map((name, i) => ({
+        id: i,
+        name,
+        avatar: pickFromArray(images),
+        unread: getRandomNumber(100),
+        last_message: {
+          type: '',
+          sender: 'Lilybon',
+          content: '123',
+          time: '10:30 PM'
+        }
+      }))
+  )

--- a/client/mocks/types.ts
+++ b/client/mocks/types.ts
@@ -32,3 +32,9 @@ export interface Message {
   imageUrl?: string,
   time: Date
 }
+
+export interface Sticker {
+  id: number,
+  name: string,
+  count: number
+}

--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -44,6 +44,7 @@ module.exports = {
   */
   buildModules: [
     '@nuxt/typescript-build',
+    '@nuxtjs/composition-api',
     '@nuxtjs/vuetify'
   ],
   /*
@@ -80,5 +81,8 @@ module.exports = {
    plugins: [new VuetifyLoaderPlugin()],
     extend (config, ctx) {
     }
+  },
+  generate: {
+    interval: 2000,
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.13.1",
+    "@nuxtjs/composition-api": "^0.22.1",
     "@nuxtjs/pwa": "^3.3.4",
     "@nuxtjs/vuetify": "^1.11.3",
     "cross-env": "^7.0.3",

--- a/client/pages/chatroom/_id/index.vue
+++ b/client/pages/chatroom/_id/index.vue
@@ -32,7 +32,7 @@
         :visible.sync="visible.searchBar"
       />
     </div>
-    <div ref="scroll" class="panel__main d-flex flex-column px-4">
+    <div ref="scrollRef" class="panel__main d-flex flex-column px-4">
       <component
         v-for="(message, index) in messages"
         :key="index"
@@ -77,7 +77,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive, ref, useAsync } from '@nuxtjs/composition-api'
 import {
   mdiChevronRight,
   mdiMagnify,
@@ -91,7 +91,7 @@ import Row from '~/components/ChatroomRow/index.vue'
 import TimeBar from '~/components/ChatroomTimeBar.vue'
 import Upload from '~/components/ChatroomUpload.vue'
 import StickerMenu from '~/components/ChatroomStickerMenu.vue'
-export default Vue.extend({
+export default defineComponent({
   name: 'Chatroom',
   components: {
     SearchBar,
@@ -101,28 +101,29 @@ export default Vue.extend({
     Upload,
     StickerMenu
   },
-  data () {
+  setup () {
+    const scrollRef = ref(null)
+    const message = ref('')
+    const visible = reactive({
+      searchBar: false
+    })
+    const messages = useAsync(() => getChatroomMessages())
+
+    // TODO: fix element refs type check
+    const scrollToBottom = () => {
+      // scrollRef.value instanceof HTMLElement && (scrollRef.value.scrollTop = scrollRef.value.scroll.height)
+    }
+
     return {
       mdiChevronRight,
       mdiMagnify,
       mdiSend,
       mdiMicrophoneOutline,
-      message: '',
-      messages: [],
-      visible: {
-        searchBar: false
-      }
-    }
-  },
-  methods: {
-    scrollToBottom () {
-      this.$refs.scroll instanceof HTMLElement && (this.$refs.scroll.scrollTop = this.$refs.scroll.scrollHeight)
-    }
-  },
-  async asyncData () {
-    const messages = await getChatroomMessages()
-    return {
-      messages
+      message,
+      messages,
+      scrollRef,
+      visible,
+      scrollToBottom
     }
   }
 })

--- a/client/pages/chatroom/_id/info.vue
+++ b/client/pages/chatroom/_id/info.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, ref } from '@nuxtjs/composition-api'
 import {
   mdiChevronRight,
   mdiAccountPlus,
@@ -76,13 +76,13 @@ import {
   mdiInformation
 } from '@mdi/js'
 import '~/styles/settings-page.scss'
-export default Vue.extend({
+export default defineComponent({
   name: 'ChatroomInfo',
   transition: {
     name: 'slide-left',
     mode: 'out-in'
   },
-  data () {
+  setup () {
     const tabs = [
       'members',
       'media',
@@ -90,31 +90,34 @@ export default Vue.extend({
       'links',
       'GIFs'
     ]
+    const actions = [
+      {
+        label: 'add',
+        icon: mdiAccountPlus,
+        cb: () => {}
+      },
+      {
+        label: 'mute',
+        icon: mdiBellOff,
+        cb: () => {}
+      },
+      {
+        label: 'leave',
+        icon: mdiExitToApp,
+        cb: () => {}
+      },
+      {
+        label: 'report',
+        icon: mdiInformation,
+        cb: () => {}
+      }
+    ]
+    const activeTab = ref(tabs[0])
+
     return {
       mdiChevronRight,
-      activeTab: tabs[0],
-      actions: [
-        {
-          label: 'add',
-          icon: mdiAccountPlus,
-          cb: () => {}
-        },
-        {
-          label: 'mute',
-          icon: mdiBellOff,
-          cb: () => {}
-        },
-        {
-          label: 'leave',
-          icon: mdiExitToApp,
-          cb: () => {}
-        },
-        {
-          label: 'report',
-          icon: mdiInformation,
-          cb: () => {}
-        }
-      ],
+      activeTab,
+      actions,
       tabs
     }
   }

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
 })
 </script>

--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive, useRouter } from '@nuxtjs/composition-api'
 import CountrySelectorDialog from '~/components/dialog/CountrySelectorDialog.vue'
 interface User {
   country: string,
@@ -87,28 +87,31 @@ interface Data {
   user: User,
   show: Show
 }
-export default Vue.extend({
+export default defineComponent({
   name: 'login',
   layout: 'simple',
   components: {
     CountrySelectorDialog
   },
-  data () {
-    return {
-      user: {
-        country: '',
-        code: '',
-        phone: ''
-      },
-      show: {
-        country: false,
-        more: false
-      }
+  setup () {
+    const router = useRouter()
+    const user = reactive({
+      country: '',
+      code: '',
+      phone: ''
+    })
+    const show = reactive({
+      country: false,
+      more: false
+    })
+
+    const login = (): void => {
+      router.push('/')
     }
-  },
-  methods: {
-    login (): void {
-      this.$router.push('/')
+    return {
+      user,
+      show,
+      login
     }
   }
 })

--- a/client/pages/settings.vue
+++ b/client/pages/settings.vue
@@ -16,40 +16,44 @@
         <div :style="{ width: '5.9375rem' }"></div>
       </div>
     </div>
-    <div ref="scroll" class="panel__main accent darken-1">
+    <div ref="scrollRef" class="panel__main accent darken-1">
       <nuxt-child class="settings" />
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { computed, defineComponent, nextTick, ref, useRoute, useRouter, watch } from '@nuxtjs/composition-api';
 import { mdiChevronRight } from '@mdi/js'
 import '~/styles/settings-page.scss'
-export default Vue.extend({
+export default defineComponent({
   name: 'Settings',
-  data () {
-    return {
-      headKey: 'settings',
-      mdiChevronRight
-    }
-  },
-  computed: {
-    tabName (): string {
-      return (this.$route.name || '')
+  setup () {
+    const headKey = 'settings'
+    const router = useRouter()
+    const route = useRoute()
+    const scrollRef = ref(null)
+
+    const tabName = computed(() =>
+      (route.value.name || '')
         .replace(/\-/g, ' ')
-        .slice(this.headKey.length + 1)
+        .slice(headKey.length + 1)
+    )
+
+    // TODO: fix element refs type check
+    watch(route, async () => {
+      await nextTick()
+      // scrollRef.value.scroll instanceof HTMLElement && (scrollRef.value.scroll.scrollTop = 0)
+    })
+
+    if (route.value.name === 'settings') {
+      router.replace({ name: 'settings-general-settings' })
     }
-  },
-  watch: {
-    async $route () {
-      await this.$nextTick()
-      this.$refs.scroll instanceof HTMLElement && (this.$refs.scroll.scrollTop = 0)
-    }
-  },
-  created () {
-    if (this.$route.name === 'settings') {
-      this.$router.replace({ name: 'settings-general-settings' })
+
+    return {
+      scrollRef,
+      mdiChevronRight,
+      tabName
     }
   }
 })

--- a/client/pages/settings/active-sessions.vue
+++ b/client/pages/settings/active-sessions.vue
@@ -14,18 +14,19 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
-export default Vue.extend({
+export default defineComponent({
   name: 'ActiveSessions',
   components: {
     SettingsGroup,
     SettingsRow
   },
-  data () {
+  setup () {
+    const sessions = []
+
     return {
-      sessions: []
     }
   }
 })

--- a/client/pages/settings/add-account.vue
+++ b/client/pages/settings/add-account.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'AddAccount'
 })
 </script>

--- a/client/pages/settings/appearance.vue
+++ b/client/pages/settings/appearance.vue
@@ -43,17 +43,17 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
 import { mdiChevronRight } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'Appearance',
   components: {
     SettingsGroup,
      SettingsRow
   },
-  data () {
+  setup () {
     return {
       mdiChevronRight
     }

--- a/client/pages/settings/blocked-users.vue
+++ b/client/pages/settings/blocked-users.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'BlockedUsers'
 })
 </script>

--- a/client/pages/settings/chat-folders.vue
+++ b/client/pages/settings/chat-folders.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ChatFolders'
 })
 </script>

--- a/client/pages/settings/data-and-storage.vue
+++ b/client/pages/settings/data-and-storage.vue
@@ -139,24 +139,26 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
 import { mdiChevronRight } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'DataAndStorage',
   components: {
     SettingsGroup,
     SettingsRow
   },
-  data () {
+  setup () {
+    const control = reactive({
+      autoDownloadMedia: true,
+      gifs: true,
+      videos: true
+    })
+
     return {
       mdiChevronRight,
-      control: {
-        autoDownloadMedia: true,
-        gifs: true,
-        videos: true
-      }
+      control
     }
   }
 })

--- a/client/pages/settings/edit-profile.vue
+++ b/client/pages/settings/edit-profile.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'EditProfile'
 })
 </script>

--- a/client/pages/settings/files.vue
+++ b/client/pages/settings/files.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'Files'
 })
 </script>

--- a/client/pages/settings/forwarded-messages.vue
+++ b/client/pages/settings/forwarded-messages.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ForwardedMessages'
 })
 </script>

--- a/client/pages/settings/general-settings.vue
+++ b/client/pages/settings/general-settings.vue
@@ -152,42 +152,46 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
 import SettingsRadio from '~/components/SettingsRadio.vue'
 import { mdiChevronRight } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'GeneralSettings',
   components: {
     SettingsGroup,
     SettingsRow,
     SettingsRadio
   },
-  data () {
+  setup () {
+    const control = reactive({
+      showStickerSidebar: true,
+      replaceEmojiAuto: false,
+      largeEmoji: true,
+      showCallsTab: true,
+      showIconsInMenuBar: false,
+      inAppSounds: false,
+      copyTextFormat: true,
+      acceptSecretChats: true,
+      forceTouchAction: 0,
+      inputSettings: 0
+    })
+    const forceTouchActions = [
+      { label: 'reply on message', value: 0 },
+      { label: 'edit message', value: 1 },
+      { label: 'forward message', value: 2 }
+    ]
+    const inputSettings = [
+      { label: 'send with enter', value: 0 },
+      { label: 'send with ⌘ + enter', value: 1 }
+    ]
+
     return {
       mdiChevronRight,
-      control: {
-        showStickerSidebar: true,
-        replaceEmojiAuto: false,
-        largeEmoji: true,
-        showCallsTab: true,
-        showIconsInMenuBar: false,
-        inAppSounds: false,
-        copyTextFormat: true,
-        acceptSecretChats: true,
-        forceTouchAction: 0,
-        inputSettings: 0
-      },
-      forceTouchActions: [
-        { label: 'reply on message', value: 0 },
-        { label: 'edit message', value: 1 },
-        { label: 'forward message', value: 2 }
-      ],
-      inputSettings: [
-        { label: 'send with enter', value: 0 },
-        { label: 'send with ⌘ + enter', value: 1 }
-      ]
+      control,
+      forceTouchActions,
+      inputSettings
     }
   }
 })

--- a/client/pages/settings/groups-and-channels.vue
+++ b/client/pages/settings/groups-and-channels.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'GroupsAndChannels'
 })
 </script>

--- a/client/pages/settings/keyboard-shortcuts.vue
+++ b/client/pages/settings/keyboard-shortcuts.vue
@@ -25,68 +25,70 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
-export default Vue.extend({
+export default defineComponent({
   name: 'KeyboardShortcuts',
   components: {
     SettingsGroup,
     SettingsRow
   },
-  data () {
+  setup () {
+    const shortcuts = [
+      {
+        label: 'chat',
+        list: [
+          { label: 'open info', value: '→' },
+          { label: 'select message to reply', value: '⌘↑/⌘↓' },
+          { label: 'edit lasst message', value: '↑' },
+          { label: 'record voice/video message', value: '⌘R' },
+          { label: 'search messages', value: '⌘F' }
+        ]
+      },
+      {
+        label: 'search',
+        list: [
+          { label: 'quick search', value: '⌘K' },
+          { label: 'global search', value: '⇧⌘F' }
+        ]
+      },
+      {
+        label: 'markdown',
+        list: [
+          { label: 'bold', value: '⌘B/**' },
+          { label: 'italic', value: '⌘I/_' },
+          { label: 'monospace', value: '⇧⌘K/`' },
+          { label: 'hyperlink', value: '⌘U' },
+          { label: 'strikethrough', value: '~~' }
+        ]
+      },
+      {
+        label: 'others',
+        list: [
+          { label: 'lock on passcode', value: '⌘L' }
+        ]
+      },
+      {
+        label: 'mouse',
+        list: [
+          { label: 'fast reply', value: 'double click' },
+          { label: 'schedule a message', value: 'option click on \'send message\'' }
+        ]
+      },
+      {
+        label: 'gesture',
+        list: [
+          { label: 'reply', value: 'swipe from right to left' },
+          { label: 'chat list actions', value: 'swipe left or right' },
+          { label: 'navigation back', value: 'swipe from left to right' },
+          { label: 'sticker/emoji/GIF panel', value: 'swipe left or right' },
+        ]
+      }
+    ]
+
     return {
-      shortcuts: [
-        {
-          label: 'chat',
-          list: [
-            { label: 'open info', value: '→' },
-            { label: 'select message to reply', value: '⌘↑/⌘↓' },
-            { label: 'edit lasst message', value: '↑' },
-            { label: 'record voice/video message', value: '⌘R' },
-            { label: 'search messages', value: '⌘F' }
-          ]
-        },
-        {
-          label: 'search',
-          list: [
-            { label: 'quick search', value: '⌘K' },
-            { label: 'global search', value: '⇧⌘F' }
-          ]
-        },
-        {
-          label: 'markdown',
-          list: [
-            { label: 'bold', value: '⌘B/**' },
-            { label: 'italic', value: '⌘I/_' },
-            { label: 'monospace', value: '⇧⌘K/`' },
-            { label: 'hyperlink', value: '⌘U' },
-            { label: 'strikethrough', value: '~~' }
-          ]
-        },
-        {
-          label: 'others',
-          list: [
-            { label: 'lock on passcode', value: '⌘L' }
-          ]
-        },
-        {
-          label: 'mouse',
-          list: [
-            { label: 'fast reply', value: 'double click' },
-            { label: 'schedule a message', value: 'option click on \'send message\'' }
-          ]
-        },
-        {
-          label: 'gesture',
-          list: [
-            { label: 'reply', value: 'swipe from right to left' },
-            { label: 'chat list actions', value: 'swipe left or right' },
-            { label: 'navigation back', value: 'swipe from left to right' },
-            { label: 'sticker/emoji/GIF panel', value: 'swipe left or right' },
-          ]
-        }
-      ]
+      shortcuts
     }
   }
 })

--- a/client/pages/settings/language.vue
+++ b/client/pages/settings/language.vue
@@ -18,84 +18,87 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
 import SettingsRadio from '~/components/SettingsRadio.vue'
-export default Vue.extend({
+export default defineComponent({
   name: 'Language',
   components: {
     SettingsGroup,
     SettingsRow,
     SettingsRadio
   },
-  data () {
-    return {
-      control: {
-        lang: 'english'
+  setup () {
+    const control = reactive({
+      lang: 'english'
+    })
+    const langs = [
+      {
+        title: 'english',
+        subtitle: 'english',
+        value: 'english'
       },
-      langs: [
-        {
-          title: 'english',
-          subtitle: 'english',
-          value: 'english'
-        },
-        {
-          title: 'catalan',
-          subtitle: 'catalan',
-          value: 'catalan'
-        },
-        {
-          title: 'dutch',
-          subtitle: 'dutch',
-          value: 'dutch'
-        },
-        {
-          title: 'french',
-          subtitle: 'french',
-          value: 'french'
-        },
-        {
-          title: 'german',
-          subtitle: 'german',
-          value: 'german'
-        },
-        {
-          title: 'italian',
-          subtitle: 'italian',
-          value: 'italian'
-        },
-        {
-          title: 'malay',
-          subtitle: 'malay',
-          value: 'malay'
-        },
-        {
-          title: 'portuguese (brazil)',
-          subtitle: 'portuguese (brazil)',
-          value: 'portuguese (brazil)'
-        },
-        {
-          title: 'russian',
-          subtitle: 'russian',
-          value: 'russian'
-        },
-        {
-          title: 'spanish',
-          subtitle: 'spanish',
-          value: 'spanish'
-        },
-        {
-          title: 'turkish',
-          subtitle: 'turkish',
-          value: 'turkish'
-        },
-        {
-          title: 'ukarainian',
-          subtitle: 'ukarainian',
-          value: 'karainian'
-        }
-      ]
+      {
+        title: 'catalan',
+        subtitle: 'catalan',
+        value: 'catalan'
+      },
+      {
+        title: 'dutch',
+        subtitle: 'dutch',
+        value: 'dutch'
+      },
+      {
+        title: 'french',
+        subtitle: 'french',
+        value: 'french'
+      },
+      {
+        title: 'german',
+        subtitle: 'german',
+        value: 'german'
+      },
+      {
+        title: 'italian',
+        subtitle: 'italian',
+        value: 'italian'
+      },
+      {
+        title: 'malay',
+        subtitle: 'malay',
+        value: 'malay'
+      },
+      {
+        title: 'portuguese (brazil)',
+        subtitle: 'portuguese (brazil)',
+        value: 'portuguese (brazil)'
+      },
+      {
+        title: 'russian',
+        subtitle: 'russian',
+        value: 'russian'
+      },
+      {
+        title: 'spanish',
+        subtitle: 'spanish',
+        value: 'spanish'
+      },
+      {
+        title: 'turkish',
+        subtitle: 'turkish',
+        value: 'turkish'
+      },
+      {
+        title: 'ukarainian',
+        subtitle: 'ukarainian',
+        value: 'karainian'
+      }
+    ]
+
+    return {
+      control,
+      langs
     }
   }
 })

--- a/client/pages/settings/last-seen.vue
+++ b/client/pages/settings/last-seen.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'LastSeen'
 })
 </script>

--- a/client/pages/settings/network-usage.vue
+++ b/client/pages/settings/network-usage.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'NetworkUsage'
 })
 </script>

--- a/client/pages/settings/notifications.vue
+++ b/client/pages/settings/notifications.vue
@@ -147,30 +147,32 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
-export default Vue.extend({
+export default defineComponent({
   name: 'Notifications',
   components: {
     SettingsGroup,
     SettingsRow
   },
-  data () {
+  setup () {
+    const control = reactive({
+      notifications: true,
+      messagePreview: false,
+      notificationTone: true,
+      bounceDockerIcon: true,
+      resetNotification: false,
+      enabled: false,
+      includeGroups: true,
+      includeChannels: true,
+      countUnreadMessage: false,
+      newContacts: true,
+      showNotifications: false
+    })
+
     return {
-      control: {
-        notifications: true,
-        messagePreview: false,
-        notificationTone: true,
-        bounceDockerIcon: true,
-        resetNotification: false,
-        enabled: false,
-        includeGroups: true,
-        includeChannels: true,
-        countUnreadMessage: false,
-        newContacts: true,
-        showNotifications: false
-      }
+      control
     }
   }
 })

--- a/client/pages/settings/passcode.vue
+++ b/client/pages/settings/passcode.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'Passcode'
 })
 </script>

--- a/client/pages/settings/phone-number.vue
+++ b/client/pages/settings/phone-number.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'PhoneNumber'
 })
 </script>

--- a/client/pages/settings/photos.vue
+++ b/client/pages/settings/photos.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'Photos'
 })
 </script>

--- a/client/pages/settings/privacy-and-security.vue
+++ b/client/pages/settings/privacy-and-security.vue
@@ -104,37 +104,41 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
 import { mdiChevronRight } from '@mdi/js'
-export default Vue.extend({
+export default defineComponent({
   name: 'PrivacyAndSecurity',
   components: {
     SettingsGroup,
     SettingsRow
   },
-  data () {
+  setup () {
+    const control = reactive({
+      suggestFrequentContacts: true,
+      deleteMyAccount: 0
+    })
+    const privacies = [
+      { title: 'phone number', subtitle: 'my contacts' },
+      { title: 'last seen', subtitle: 'everybody' },
+      { title: 'groups and channels', subtitle: 'everybody' },
+      { title: 'voice calls', subtitle: 'everybody' },
+      { title: 'profile photo', subtitle: 'everybody' },
+      { title: 'forwarded messages', subtitle: 'everybody' }
+    ]
+    const deleteMyAccountOptions = [
+      { text: '1 month', value: 0 },
+      { text: '3 months', value: 1 },
+      { text: '9 months', value: 2 },
+      { text: '1 year', value: 3 }
+    ]
+
     return {
       mdiChevronRight,
-      control: {
-        suggestFrequentContacts: true,
-        deleteMyAccount: 0
-      },
-      privacies: [
-        { title: 'phone number', subtitle: 'my contacts' },
-        { title: 'last seen', subtitle: 'everybody' },
-        { title: 'groups and channels', subtitle: 'everybody' },
-        { title: 'voice calls', subtitle: 'everybody' },
-        { title: 'profile photo', subtitle: 'everybody' },
-        { title: 'forwarded messages', subtitle: 'everybody' }
-      ],
-      deleteMyAccountOptions: [
-        { text: '1 month', value: 0 },
-        { text: '3 months', value: 1 },
-        { text: '9 months', value: 2 },
-        { text: '1 year', value: 3 }
-      ]
+      control,
+      privacies,
+      deleteMyAccountOptions
     }
   }
 })

--- a/client/pages/settings/profile-photo.vue
+++ b/client/pages/settings/profile-photo.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'ProfilePhoto'
 })
 </script>

--- a/client/pages/settings/stickers.vue
+++ b/client/pages/settings/stickers.vue
@@ -63,50 +63,27 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { defineComponent, reactive, useAsync } from '@nuxtjs/composition-api'
 import SettingsGroup from '~/components/wrapper/SettingsGroup.vue'
 import SettingsRow from '~/components/wrapper/SettingsRow.vue'
 import { mdiChevronRight, mdiTrashCanOutline } from '@mdi/js'
-export default Vue.extend({
+import { getStickers } from '~/mocks'
+export default defineComponent({
   name: 'Stickers',
   components: {
     SettingsGroup,
     SettingsRow
   },
-  data () {
+  setup () {
+    const control = reactive({
+      loopAnimatedStickers: true
+    })
+    const stickers = useAsync(() => getStickers())
     return {
       mdiChevronRight,
       mdiTrashCanOutline,
-      control: {
-        loopAnimatedStickers: true
-      },
-      stickers: [
-        {
-          id: 1,
-          name: '杰哥不要啦',
-          count: 120
-        },
-        {
-          id: 2,
-          name: 'igotallday_fans',
-          count: 28
-        },
-        {
-          id: 3,
-          name: 'Peepo pepe',
-          count: 30
-        },
-        {
-          id: 4,
-          name: 'Bobby Hill',
-          count: 22
-        },
-        {
-          id: 5,
-          name: 'PEPEtopAnim',
-          count: 50
-        }
-      ]
+      control,
+      stickers
     }
   }
 })

--- a/client/pages/settings/storage-usage.vue
+++ b/client/pages/settings/storage-usage.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'StorageUsage'
 })
 </script>

--- a/client/pages/settings/two-step-validation.vue
+++ b/client/pages/settings/two-step-validation.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'TwoStepValidation'
 })
 </script>

--- a/client/pages/settings/use-proxy.vue
+++ b/client/pages/settings/use-proxy.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'UseProxy'
 })
 </script>

--- a/client/pages/settings/videos.vue
+++ b/client/pages/settings/videos.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'Videos'
 })
 </script>

--- a/client/pages/settings/voice-calls.vue
+++ b/client/pages/settings/voice-calls.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from '@nuxtjs/composition-api'
+export default defineComponent({
   name: 'VoiceCalls'
 })
 </script>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1502,6 +1502,18 @@
     consola "^2.15.3"
     defu "^3.2.2"
 
+"@nuxtjs/composition-api@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/composition-api/-/composition-api-0.22.1.tgz#aa14065b489bbdd3ce72f32132d8a7ffd96ac1a6"
+  integrity sha512-47yAd9GCj2K7OLmM/U03LkldNyXU0zGEjgUrIodD/2vMZArGjFsPoRns6K4oIvvUKeia8MXzjEMYxAsSm5IFlw==
+  dependencies:
+    "@vue/composition-api" "1.0.0-rc.5"
+    defu "^3.2.2"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+    ufo "^0.6.10"
+    upath "^2.0.1"
+
 "@nuxtjs/eslint-config-typescript@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-6.0.0.tgz#e3ea273edf2dfcb176a9f28ca1a95870a6c21cd8"
@@ -2125,6 +2137,13 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
+
+"@vue/composition-api@1.0.0-rc.5":
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-rc.5.tgz#9b857743dd2692073b6df90fa2cfb9a75a1bb2f6"
+  integrity sha512-sFBUDZxwi5YOQqH//VSGenO6WH0JuW94+CWo1eUsGSTRue8POfwD4oeduVqi/c6QcwXg2tJL/m6aOD2t/IR6zg==
+  dependencies:
+    tslib "^2.1.0"
 
 "@vue/test-utils@^1.1.3":
   version "1.1.3"
@@ -4771,6 +4790,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -7163,6 +7187,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -10049,6 +10080,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -10706,7 +10742,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
@@ -10803,6 +10839,11 @@ ua-parser-js@^0.7.24:
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
   integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+
+ufo@^0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.6.10.tgz#c7ace9b8f72cb08c35e3a8c8edc76f062fbaa7d0"
+  integrity sha512-sMbJnrBcKKsbVyr6++hb0n9lCmrMqkJrNnJIOJ3sckeqY6NMfAULcRGbBWcASSnN1HDV3YqiGCPzi9RVs511bw==
 
 ufo@^0.6.7:
   version "0.6.9"


### PR DESCRIPTION
To take a advantage on designing reuse-able function hook,
I change components, layouts and pages syntax under this project from optional api to composition api.

But Vue template refs couldn't be passed by typescript checking, more detail on `page/settings.vue`.
I will figure out what happened ASAP.

```javascript
scrollRef.value.scroll instanceof HTMLElement && (scrollRef.value.scroll.scrollTop = 0)
```

Anyway, let's use composition api ~